### PR TITLE
Message output format

### DIFF
--- a/src/anvilmapper/AnvilMapper.java
+++ b/src/anvilmapper/AnvilMapper.java
@@ -71,7 +71,7 @@ public class AnvilMapper {
     							}
     						} 
     						else {
-    							System.out.println("image file " + imageFile + "did not pass the file name check");
+    							System.out.println("image file " + imageFile + " did not pass the file name check");
     						}
     					}
     				}


### PR DESCRIPTION
The wrong image error message was not formatted correctly. Additionally, the problem tries to process the thumbnail files Windows generates so this should be corrected by having the program ignore them.
